### PR TITLE
Changed Tc3JsonXmlSampleXmlDomReader Sample so Option 2 Will Iterate Each Cycle.

### DIFF
--- a/Tc3JsonXmlSampleXmlDomReader/PlcTc3JsonXmlSampleXmlDomReader/POUs/MAIN.TcPOU
+++ b/Tc3JsonXmlSampleXmlDomReader/PlcTc3JsonXmlSampleXmlDomReader/POUs/MAIN.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.11">
   <POU Name="MAIN" Id="{ed120519-6aa8-4fd0-87ed-ffa0c7751332}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM MAIN
 VAR
@@ -48,6 +48,9 @@ WHILE NOT fbXml.IsEnd(xmlIterator) DO
 	XmlIterator := fbXml.Next(XmlIterator);
 END_WHILE
 
+(* End the iterator so it can be reset for the next cycle *)
+xmlIterator := fbXml.End(xmlMachineNode);
+
 (* Parse XML attributes *)
 xmlMachine1Attribute := fbXml.Attribute(xmlMachine1, 'Type');
 xmlMachine2Attribute := fbXml.Attribute(xmlMachine2, 'Type');
@@ -71,7 +74,10 @@ nMachine2Attribute := fbXml.AttributeAsInt(xmlMachine2Attribute);
       <LineId Id="118" Count="0" />
       <LineId Id="114" Count="0" />
       <LineId Id="59" Count="0" />
-      <LineId Id="14" Count="11" />
+      <LineId Id="150" Count="0" />
+      <LineId Id="14" Count="0" />
+      <LineId Id="148" Count="1" />
+      <LineId Id="15" Count="10" />
       <LineId Id="2" Count="0" />
     </LineIds>
   </POU>

--- a/Tc3JsonXmlSampleXmlDomReader/Tc3JsonXmlSampleXmlDomReader.sln
+++ b/Tc3JsonXmlSampleXmlDomReader/Tc3JsonXmlSampleXmlDomReader.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# TcXaeShell Solution File, Format Version 11.00
+# Visual Studio 15
 VisualStudioVersion = 15.0.28307.1300
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{B1E792BE-AA5F-4E3C-8C82-674BF9C0715B}") = "Tc3JsonXmlSampleXmlDomReader", "Tc3JsonXmlSampleXmlDomReader.tsproj", "{F8F0629B-2757-4526-B06F-2FE3977EC654}"


### PR DESCRIPTION
In the current example the iterator createdon line 13 of MAIN is not reset and the document is not iterated through after the first cycle. 
![image](https://user-images.githubusercontent.com/27658077/172222508-5b66fc41-a72c-4845-8587-955ec5e0b966.png)

If changes are made to the XML document, the user will need to re-iterate through the nodes for values again. The current sample does not provide an example of how to reset the iterator. Adding a call to XmlDomParser.End() will have the iterator reset to on the next cycle.
![image](https://user-images.githubusercontent.com/27658077/172222627-d01ebbba-aa92-4387-b6e6-d36cefb35127.png)
